### PR TITLE
Add Worker::is_same_as

### DIFF
--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -262,6 +262,11 @@ impl<T> Worker<T> {
         Worker { queue }
     }
 
+    /// Checks if the [`Worker`] points to the same underlying queue as a [`Stealer`].
+    pub fn is_same_as(&self, stealer: &Stealer<T>) -> bool {
+        Arc::ptr_eq(&self.queue, &stealer.queue)
+    }
+
     /// Creates a new `Stealer` handle associated to this `Worker`.
     ///
     /// An arbitrary number of `Stealer` handles can be created, either using

--- a/src/lifo.rs
+++ b/src/lifo.rs
@@ -306,6 +306,11 @@ impl<T> Worker<T> {
         Worker { queue }
     }
 
+    /// Checks if the [`Worker`] points to the same underlying queue as a [`Stealer`].
+    pub fn is_same_as(&self, stealer: &Stealer<T>) -> bool {
+        Arc::ptr_eq(&self.queue, &stealer.queue)
+    }
+
     /// Creates a new `Stealer` handle associated to this `Worker`.
     ///
     /// An arbitrary number of `Stealer` handles can be created, either using

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -26,6 +26,27 @@ fn lifo_rotate<T: Default + std::fmt::Debug>(worker: &lifo::Worker<T>, n: usize)
     }
 }
 
+
+#[test]
+fn fifo_is_same_as() {
+    let worker_a = fifo::Worker::<u32>::new(32);
+    let worker_b = fifo::Worker::<u32>::new(32);
+    assert!(worker_a.is_same_as(&worker_a.stealer()));
+    assert!(!worker_b.is_same_as(&worker_a.stealer()));
+    assert!(!worker_a.is_same_as(&worker_b.stealer()));
+    assert!(worker_b.is_same_as(&worker_b.stealer()));
+}
+
+#[test]
+fn lifo_is_same_as() {
+    let worker_a = lifo::Worker::<u32>::new(32);
+    let worker_b = lifo::Worker::<u32>::new(32);
+    assert!(worker_a.is_same_as(&worker_a.stealer()));
+    assert!(!worker_b.is_same_as(&worker_a.stealer()));
+    assert!(!worker_a.is_same_as(&worker_b.stealer()));
+    assert!(worker_b.is_same_as(&worker_b.stealer()));
+}
+
 #[test]
 fn fifo_single_threaded_steal() {
     const ROTATIONS: &[usize] = if cfg!(miri) {


### PR DESCRIPTION
Add a shim for `Arc::ptr_eq` for lifo/fifo Worker in the form of `Worker::is_same_as`. Fixes #2.