### PR TITLE
Replace cache-padded with crossbeam-utils

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ autotests = false
 autobenches = false
 
 [dependencies]
-cache-padded = "1.1"
+crossbeam-utils = { version = "0.8.14", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/fifo.rs
+++ b/src/fifo.rs
@@ -43,7 +43,7 @@ use core::mem::{drop, MaybeUninit};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
 
-use cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 
 use crate::config::{AtomicUnsignedLong, AtomicUnsignedShort, UnsignedShort};
 use crate::loom_exports::cell::UnsafeCell;

--- a/src/lifo.rs
+++ b/src/lifo.rs
@@ -43,7 +43,7 @@ use core::mem::{drop, MaybeUninit};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
-use cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 
 use crate::config::{AtomicUnsignedLong, AtomicUnsignedShort, UnsignedShort};
 use crate::loom_exports::cell::UnsafeCell;


### PR DESCRIPTION
[We are currently planning on deprecating `cache-padded`](https://github.com/smol-rs/cache-padded/issues/10) and replacing it with `crossbeam-utils`' `CachePadded` structure. This PR replaces the usage of `cache-padded` with `crossbeam-utils`, which should be a 1-to-1 change.