### PR TITLE
Add `Worker::stealer_ref` + impl. `Eq` for stealer

### DIFF
--- a/src/lifo.rs
+++ b/src/lifo.rs
@@ -38,8 +38,9 @@
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 
+use core::alloc::Layout;
 use core::iter::FusedIterator;
-use core::mem::{drop, MaybeUninit};
+use core::mem::{drop, transmute, MaybeUninit};
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
@@ -316,6 +317,26 @@ impl<T> Worker<T> {
         }
     }
 
+    /// Creates a reference to a `Stealer` handle associated to this `Worker`.
+    ///
+    /// This is a zero-cost reference-to-reference conversion: the reference
+    /// count to the underlying queue is not modified. The returned reference
+    /// can in particular be used to perform a cheap equality check with another
+    /// `Stealer` and verify that it is associated to the same `Worker`.
+    pub fn stealer_ref(&self) -> &Stealer<T> {
+        // Sanity checks to assess that `queue` has indeed the size and
+        // alignment of a `Stealer` (this assert is optimized in release mode).
+        assert_eq!(Layout::for_value(&self.queue), Layout::new::<Stealer<T>>());
+
+        // Safety: `self.queue` has the size and alignment of `Stealer` since
+        // the latter is a `repr(transparent)` type over an `Arc<Queue<T>>`. The
+        // lifetime of the returned reference is bounded by the lifetime of
+        // `&self`. The soundness of providing a `Stealer` from a `Worker` is
+        // already assumed by the `stealer()` method, so providing a short-lived
+        // reference to a `Stealer` does not in itself modify safety guarantees.
+        unsafe { transmute::<&'_ Arc<Queue<T>>, &'_ Stealer<T>>(&self.queue) }
+    }
+
     /// Returns the capacity of the queue.
     pub fn capacity(&self) -> usize {
         self.queue.capacity() as usize
@@ -399,8 +420,8 @@ impl<T> Worker<T> {
     ///
     /// It is the responsibility of the caller to ensure that there is enough
     /// spare capacity to accommodate all iterator items, for instance by
-    /// calling `[Worker::spare_capacity]` beforehand. Otherwise, the iterator
-    /// is dropped while still holding the excess items.
+    /// calling [`spare_capacity`](Worker::spare_capacity) beforehand.
+    /// Otherwise, the iterator is dropped while still holding the excess items.
     pub fn extend<I: IntoIterator<Item = T>>(&self, iter: I) {
         let push_count = self.queue.push_count.load(Relaxed);
         let pop_count = unpack(self.queue.pop_count_and_head.load(Relaxed)).0;
@@ -591,6 +612,7 @@ unsafe impl<'a, T: Send> Sync for Drain<'a, T> {}
 
 /// Handle for multi-threaded stealing operations.
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct Stealer<T> {
     queue: Arc<Queue<T>>,
 }
@@ -747,6 +769,14 @@ impl<T> Clone for Stealer<T> {
         }
     }
 }
+
+impl<T> PartialEq for Stealer<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.queue, &other.queue)
+    }
+}
+
+impl<T> Eq for Stealer<T> {}
 
 impl<T> UnwindSafe for Stealer<T> {}
 impl<T> RefUnwindSafe for Stealer<T> {}

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -26,6 +26,42 @@ fn lifo_rotate<T: Default + std::fmt::Debug>(worker: &lifo::Worker<T>, n: usize)
     }
 }
 
+macro_rules! stealer_equality {
+    ($flavor:ident, $test_name:ident) => {
+        #[test]
+        fn $test_name() {
+            let worker_a = $flavor::Worker::<u32>::new(32);
+            let worker_b = $flavor::Worker::<u32>::new(32);
+
+            assert_eq!(worker_a.stealer(), worker_a.stealer());
+            assert_ne!(worker_b.stealer(), worker_a.stealer());
+            assert_eq!(worker_b.stealer(), worker_b.stealer());
+            assert_ne!(worker_a.stealer(), worker_b.stealer());
+        }
+    };
+}
+
+stealer_equality!(fifo, fifo_stealer_equality);
+stealer_equality!(lifo, lifo_stealer_equality);
+
+macro_rules! stealer_ref_equality {
+    ($flavor:ident, $test_name:ident) => {
+        #[test]
+        fn $test_name() {
+            let worker_a = $flavor::Worker::<u32>::new(32);
+            let worker_b = $flavor::Worker::<u32>::new(32);
+
+            assert_eq!(worker_a.stealer_ref(), &worker_a.stealer());
+            assert_ne!(worker_b.stealer_ref(), &worker_a.stealer());
+            assert_eq!(worker_b.stealer_ref(), &worker_b.stealer());
+            assert_ne!(worker_a.stealer_ref(), &worker_b.stealer());
+        }
+    };
+}
+
+stealer_ref_equality!(fifo, fifo_ref_stealer_equality);
+stealer_ref_equality!(lifo, lifo_ref_stealer_equality);
+
 #[test]
 fn fifo_single_threaded_steal() {
     const ROTATIONS: &[usize] = if cfg!(miri) {


### PR DESCRIPTION
This commits makes it possible to obtain a cheap reference to a `Stealer` from a `Worker` and implements `Eq`/`PartialEq` on `Stealer`.

These 2 features can be combined to check whether a stealer is associated to a given worker, which closes #2.